### PR TITLE
fix TOC

### DIFF
--- a/src/components/TOC.tsx
+++ b/src/components/TOC.tsx
@@ -120,6 +120,27 @@ const TOCInline = ({
 		}
 	}, [toc])
 
+	useEffect(() => {
+		if (activeId) {
+			const tocItem = document.getElementById(`toc-item-${activeId}`)
+			if (tocItem) {
+				// 找到最近的滚动父元素
+				let parent = tocItem.parentElement
+				while (parent && parent !== document.body) {
+					const overflowY = window.getComputedStyle(parent).overflowY
+					if (overflowY === 'auto' || overflowY === 'scroll') {
+						const parentRect = parent.getBoundingClientRect()
+						const targetRect = tocItem.getBoundingClientRect()
+						const offset = targetRect.top - parentRect.top - parent.clientHeight / 2 + tocItem.clientHeight / 2
+						parent.scrollBy({ top: offset, behavior: 'smooth' })
+						break
+					}
+					parent = parent.parentElement
+				}
+			}
+		}
+	}, [activeId])
+
 	// 在 Hooks 调用之后处理早期返回
 	if (!toc) {
 		return null
@@ -151,8 +172,9 @@ const TOCInline = ({
 	const handleItemClick = (id: string) => {
 		clickedId.current = id
 		setActiveId(id)
+		
 		// eslint-disable-next-line react-compiler/react-compiler
-		window.location.hash = `#${activeId}`
+		window.location.hash = `#${id}`
 		const targetElement = document.getElementById(id)
 		if (targetElement) {
 			targetElement.scrollIntoView({
@@ -177,6 +199,7 @@ const TOCInline = ({
 				{items.map((item, index) => (
 					<li key={`${item.url}_${index}`}>
 						<a
+							id={`toc-item-${item.url.slice(1)}`}
 							className={`underline-offset-2 ${
 								activeId === item.url.slice(1)
 									? 'font-semibold text-blue-11 dark:text-skydark-11'

--- a/src/layouts/PostLayout.tsx
+++ b/src/layouts/PostLayout.tsx
@@ -75,26 +75,15 @@ export default function PostLayout({
 		<>
 			<ScrollTopAndComment toc={toc} />
 			<article>
-				<div className='mx-auto'>
-					{/* 文章头部 */}
-					<PostHeader
-						date={date}
-						title={title}
-						pinned={pinned}
-						readingTime={content.readingTime}
-					/>
-
+				<div className='mx-auto px-4 sm:px-6 xl:px-0'>
 					<div className='flex flex-col lg:flex-row'>
-						{/* 作者信息（移动端显示在顶部） */}
-						<div className='order-1 lg:hidden'>
-							<AuthorSection authorDetails={authorDetails} />
-						</div>
-						{/* 左侧边栏（桌面端） */}
-						<div className='hidden lg:order-1 lg:block lg:pl-6'>
-							<aside className='sticky top-20 hidden pl-5 lg:block lg:max-w-[220px]'>
-								{/* 作者信息 */}
+						{/* 左侧边栏（桌面端）及作者信息（移动端） */}
+						<div className='order-1 lg:block lg:pl-6 xl:pl-8 lg:w-[220px] 2xl:w-[280px] shrink-0'>
+							<div className='lg:hidden'>
 								<AuthorSection authorDetails={authorDetails} />
-								{/* 文章导航 */}
+							</div>
+							<aside className='sticky top-20 hidden lg:block'>
+								<AuthorSection authorDetails={authorDetails} />
 								<PostNavigation
 									categories={categories}
 									tags={tags}
@@ -107,9 +96,17 @@ export default function PostLayout({
 						</div>
 
 						{/* 主内容区域 */}
-						<div className='order-1 divide-y divide-slate-5 lg:order-2 lg:flex-1 dark:divide-slatedark-5'>
+						<div className='order-2 divide-y divide-slate-5 lg:flex-1 dark:divide-slatedark-5 lg:px-8 xl:px-12 2xl:px-16 min-w-0'>
+							{/* 文章头部 */}
+							<PostHeader
+								date={date}
+								title={title}
+								pinned={pinned}
+								readingTime={content.readingTime}
+							/>
+
 							{/* 文章内容 */}
-							<div className='prose prose-slate dark:prose-invert mx-auto pt-10 pb-8'>
+							<div className='prose prose-slate dark:prose-invert max-w-none pt-10 pb-8'>
 								{children}
 							</div>
 
@@ -132,13 +129,13 @@ export default function PostLayout({
 						</div>
 
 						{/* 目录 - 右侧边栏（仅桌面显示） */}
-						<div className='hidden lg:order-3 lg:block lg:w-1/5 lg:min-w-[200px] lg:pl-6'>
+						<div className='hidden lg:order-3 lg:block lg:w-[240px] xl:w-[280px] shrink-0 lg:pr-6 xl:pr-8'>
 							<TableOfContents toc={toc} />
 						</div>
 					</div>
 
 					{/* 导航区域（移动端显示在底部） */}
-					<div className='order-3 mt-8 lg:hidden'>
+					<div className='mt-8 lg:hidden'>
 						<PostNavigation
 							categories={categories}
 							tags={tags}
@@ -330,13 +327,15 @@ function PostNavigation({ categories, tags, next, prev, basePath, _slug }) {
 // 目录组件
 function TableOfContents({ toc }) {
 	return (
-		<div className='prose dark:prose-invert sticky top-20 pt-10 text-sm'>
-			{toc ? (
-				<h2 className='not-prose ml-5 pb-2 text-lg text-slate-11 uppercase tracking-wide dark:text-slatedark-11'>
-					TOC
-				</h2>
-			) : null}
-			<TOCInline toc={toc} />
+		<div className='prose dark:prose-invert sticky top-0 text-sm h-screen overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]'>
+			<div className='pt-20 pb-8'>
+				{toc ? (
+					<h2 className='not-prose ml-5 pb-2 text-lg text-slate-11 uppercase tracking-wide dark:text-slatedark-11'>
+						TOC
+					</h2>
+				) : null}
+				<TOCInline toc={toc} />
+			</div>
 		</div>
 	)
 }


### PR DESCRIPTION
#使右侧TOC随文章的滑动而滑动


# TOC 目录排版与交互优化总结

在本次对话中，主要针对博客文章页面（PostLayout）右侧的 TOC 目录在滚动和点击时出现的一系列排版及截断问题进行了修复。以下是所有修改内容的详细总结及对应的解决目的：

## 1. 解决目录项跟踪时“跑出可视区域外”的问题
* **修改文件**：`src/components/TOC.tsx`
* **问题描述**：当页面向下滚动，当前阅读的标题对应侧边栏的 TOC 项变蓝时，如果文章很长，高亮的蓝色 TOC 项会掉出侧边栏框下方，用户无法看见（因为没有自动跟随中心点）。
* **所做改变**：
  1. 给生成的每个目录项的 `<a>` 标签加上了唯一的 ID（`id={`toc-item-${id}`}`）。
  2. 新增了一个 `useEffect` 来监听 `activeId`。当高亮的标题改变时，自动向上寻找到 TOC 所在的可滚动父元素，计算偏移量，并通过 `scrollBy({ top: offset, behavior: 'smooth' })` 平滑滚动，**确保当前标蓝的高亮标题始终处于侧边面板内近乎居中的位置**。

## 2. 去除丑陋的默认滚动条
* **修改文件**：`src/layouts/PostLayout.tsx`
* **问题描述**：侧面因为允许单独滚动，浏览器在右侧会默认加上一条很难看的拖动（滚动）条，破坏整个页面的美观和留白。
* **所做改变**：
  * 在 TOC 侧边栏容器的 className 中添加了跨浏览器的隐藏滚动条样式：
    `[&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]`。由此保留了滚动功能但隐藏了滚动条UI。

## 3. 解决由于高度设定导致目录像“被关在一个方框里”的问题
* **修改文件**：`src/layouts/PostLayout.tsx`
* **问题描述**：原来 TOC 的父级高度被设为了 `max-h-[80vh]` 或 `calc(100vh-5rem)` 导致上下边界看起来被直接裁切，且并没有碰到页面的最顶和最底部像素。
* **所做改变**：
  * 将容器的高度修改为 `h-screen`（占满视口高度）。
  * 取消了粘性定位的顶部距离（将 `sticky top-20` 改为 `sticky top-0`）。
  * 将原本导致顶部有空白断层的 `pt-20` 的留白（Padding）从滚动容器外部挪进了滚动容器**内部的子元素身上**，这样容器本身已经牢牢吸附并碰触到了页面最顶端，不会产生边界割裂感。

## 4. 解决滚动页面时被文章 Header（标题区域）截断的问题
* **修改文件**：`src/layouts/PostLayout.tsx`
* **问题描述**：当应用了上述改进后，虽然侧边栏碰到了它自己的父框最顶端，但是如果把它往上划，依然会在经过大大的文章标题（Header区域）下方时消失被截断，无法覆盖整个屏幕视觉。
* **所做改变**：
  * **重构了文章页面的 DOM 排版布局（最重要的一步）**：之前 `PostHeader` 独立并在 flex 左右三栏的上方，导致下方三栏实际上受限于此，它的天花板最高只能到达 Header 的地脚。
  * 将 `PostHeader` 整个组件挪进了中央布局的区域里（`<div className='order-2 ... lg:flex-1'>`正文上方）。这样一来，左边作者栏、中间主内容（带Header）、右边 TOC，这三者就成为了真正的平行关系。
  * 使得右侧 TOC 列在垂直延展上彻底没有了阻碍，从而实现了真正满屏无边界地伴随文章滚动。

## 5. 修复因生命周期改动造成的 ESLint (React Rules of Hooks) 报错
* **修改文件**：`src/components/TOC.tsx`
* **问题描述**：在增加自动滚动的 `useEffect` 过程中，曾经将它放在了 `if (!toc) return null` 这样会提前 return 的语句下方，违反了 React 的 “Hook 必须在顶层被一致调用”的规范，导致 `next build` 和 `lint` 会报错退出。
* **所做改变**：
  * 调整了代码执行顺序，将所有判断提前返回 `null` 的纯逻辑放在了所有的生命周期 Hook（`useEffect`）**之后**执行，并且修复了 Hash 赋值报错。确保了代码库质量（0 error）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table of Contents now automatically scrolls to keep the active section visible within the TOC panel.

* **Bug Fixes**
  * Fixed URL hash updates when clicking Table of Contents items to correctly reflect the selected section.

* **Improvements**
  * Enhanced responsive layout with improved spacing and padding across different screen sizes.
  * Redesigned Table of Contents display as a fixed-height, internally scrollable container for better navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->